### PR TITLE
chore: promote nodey554 to version 1.0.44

### DIFF
--- a/config-root/namespaces/myapps/nodey554/nodey554-nodey554-deploy.yaml
+++ b/config-root/namespaces/myapps/nodey554/nodey554-nodey554-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nodey554-nodey554
   labels:
     draft: draft-app
-    chart: "nodey554-1.0.43"
+    chart: "nodey554-1.0.44"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: myapps
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: nodey554-nodey554
       containers:
         - name: nodey554
-          image: "gcr.io/jenkins-x-labs-bdd1/nodey554:1.0.43"
+          image: "gcr.io/jenkins-x-labs-bdd1/nodey554:1.0.44"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 1.0.43
+              value: 1.0.44
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/myapps/nodey554/nodey554-svc.yaml
+++ b/config-root/namespaces/myapps/nodey554/nodey554-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: nodey554
   labels:
-    chart: "nodey554-1.0.43"
+    chart: "nodey554-1.0.44"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,7 +40,7 @@
 		    </tr>
 	    <tr>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> nodey554 </a></td>
-	      <td>1.0.43</td>
+	      <td>1.0.44</td>
 	      <td><a href='http://nodey554-myapps.34.118.108.125.nip.io'>view</a></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -90,4 +90,4 @@
     repositoryName: dev
     repositoryUrl: http://chartmuseum-jx.35.242.181.72.nip.io/
     resourcePath: config-root/namespaces/myapps/nodey554
-    version: 1.0.43
+    version: 1.0.44

--- a/helmfiles/myapps/helmfile.yaml
+++ b/helmfiles/myapps/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://chartmuseum-jx.35.242.181.72.nip.io/
 releases:
 - chart: dev/nodey554
-  version: 1.0.43
+  version: 1.0.44
   name: nodey554
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote nodey554 to version 1.0.44

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
