### PR TITLE
chore: promote go-chaos to version 0.0.1

### DIFF
--- a/config-root/namespaces/myapps/go-chaos/go-chaos-go-chaos-deploy.yaml
+++ b/config-root/namespaces/myapps/go-chaos/go-chaos-go-chaos-deploy.yaml
@@ -1,0 +1,60 @@
+# Source: go-chaos/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: go-chaos-go-chaos
+  labels:
+    draft: draft-app
+    chart: "go-chaos-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: myapps
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: go-chaos-go-chaos
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: go-chaos-go-chaos
+    spec:
+      serviceAccountName: go-chaos-go-chaos
+      containers:
+        - name: go-chaos
+          image: "gcr.io/jenkins-x-labs-bdd1/go-chaos:0.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.1
+          envFrom: null
+          ports:
+            - name: http
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:
+        - name: "tekton-container-registry-auth"

--- a/config-root/namespaces/myapps/go-chaos/go-chaos-go-chaos-sa.yaml
+++ b/config-root/namespaces/myapps/go-chaos/go-chaos-go-chaos-sa.yaml
@@ -1,0 +1,8 @@
+# Source: go-chaos/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: go-chaos-go-chaos
+  namespace: myapps
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/myapps/go-chaos/go-chaos-ingress.yaml
+++ b/config-root/namespaces/myapps/go-chaos/go-chaos-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: go-chaos/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: go-chaos
+  namespace: myapps
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: go-chaos
+              servicePort: 80
+      host: go-chaos-myapps.34.118.108.125.nip.io

--- a/config-root/namespaces/myapps/go-chaos/go-chaos-svc.yaml
+++ b/config-root/namespaces/myapps/go-chaos/go-chaos-svc.yaml
@@ -1,0 +1,18 @@
+# Source: go-chaos/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: go-chaos
+  labels:
+    chart: "go-chaos-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: myapps
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: go-chaos-go-chaos

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,12 @@
 	      <td><a href='http://nodey554-myapps.34.118.108.125.nip.io'>view</a></td>
 	      <td></td>
 	    </tr>
+    <tr>
+	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> go-chaos </a></td>
+	      <td>0.0.1</td>
+	      <td><a href='http://go-chaos-myapps.34.118.108.125.nip.io'>view</a></td>
+	      <td></td>
+	    </tr>
 
   </tbody>
 </table>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -91,3 +91,15 @@
     repositoryUrl: http://chartmuseum-jx.35.242.181.72.nip.io/
     resourcePath: config-root/namespaces/myapps/nodey554
     version: 1.0.44
+  - apiVersion: v1
+    applicationUrl: http://go-chaos-myapps.34.118.108.125.nip.io
+    description: A Helm chart for Kubernetes
+    icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
+    ingresses:
+    - name: go-chaos
+      url: http://go-chaos-myapps.34.118.108.125.nip.io
+    name: go-chaos
+    repositoryName: dev
+    repositoryUrl: http://chartmuseum-jx.35.242.181.72.nip.io/
+    resourcePath: config-root/namespaces/myapps/go-chaos
+    version: 0.0.1

--- a/helmfiles/myapps/helmfile.yaml
+++ b/helmfiles/myapps/helmfile.yaml
@@ -16,5 +16,7 @@ releases:
 - chart: dev/go-chaos
   version: 0.0.1
   name: go-chaos
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/myapps/helmfile.yaml
+++ b/helmfiles/myapps/helmfile.yaml
@@ -13,5 +13,8 @@ releases:
   name: nodey554
   values:
   - jx-values.yaml
+- chart: dev/go-chaos
+  version: 0.0.1
+  name: go-chaos
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote go-chaos to version 0.0.1

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
