### PR TITLE
chore: promote go-chaos to version 0.0.3

### DIFF
--- a/config-root/namespaces/myapps/go-chaos/go-chaos-go-chaos-deploy.yaml
+++ b/config-root/namespaces/myapps/go-chaos/go-chaos-go-chaos-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: go-chaos-go-chaos
   labels:
     draft: draft-app
-    chart: "go-chaos-0.0.2"
+    chart: "go-chaos-0.0.3"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: myapps
   annotations:
@@ -24,11 +24,15 @@ spec:
       serviceAccountName: go-chaos-go-chaos
       containers:
         - name: go-chaos
-          image: "gcr.io/jenkins-x-labs-bdd1/go-chaos:0.0.2"
+          image: "gcr.io/jenkins-x-labs-bdd1/go-chaos:0.0.3"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.2
+              value: 0.0.3
+            - name: CRASH_DURATION
+              value: "10s"
+            - name: FAIL
+              value: "true"
           envFrom: null
           ports:
             - name: http

--- a/config-root/namespaces/myapps/go-chaos/go-chaos-svc.yaml
+++ b/config-root/namespaces/myapps/go-chaos/go-chaos-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: go-chaos
   labels:
-    chart: "go-chaos-0.0.2"
+    chart: "go-chaos-0.0.3"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: myapps
 spec:

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,7 +46,7 @@
 	    </tr>
     <tr>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> go-chaos </a></td>
-	      <td>0.0.2</td>
+	      <td>0.0.3</td>
 	      <td><a href='http://go-chaos-myapps.34.118.108.125.nip.io'>view</a></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -102,4 +102,4 @@
     repositoryName: dev
     repositoryUrl: http://chartmuseum-jx.35.242.181.72.nip.io/
     resourcePath: config-root/namespaces/myapps/go-chaos
-    version: 0.0.2
+    version: 0.0.3

--- a/helmfiles/myapps/helmfile.yaml
+++ b/helmfiles/myapps/helmfile.yaml
@@ -14,7 +14,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/go-chaos
-  version: 0.0.2
+  version: 0.0.3
   name: go-chaos
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote go-chaos to version 0.0.3

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
