### PR TITLE
chore: promote nodey554 to version 1.0.45

### DIFF
--- a/config-root/namespaces/myapps/nodey554/nodey554-nodey554-deploy.yaml
+++ b/config-root/namespaces/myapps/nodey554/nodey554-nodey554-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nodey554-nodey554
   labels:
     draft: draft-app
-    chart: "nodey554-1.0.44"
+    chart: "nodey554-1.0.45"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: myapps
   annotations:
@@ -24,14 +24,15 @@ spec:
       serviceAccountName: nodey554-nodey554
       containers:
         - name: nodey554
-          image: "gcr.io/jenkins-x-labs-bdd1/nodey554:1.0.44"
+          image: "gcr.io/jenkins-x-labs-bdd1/nodey554:1.0.45"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 1.0.44
+              value: 1.0.45
           envFrom: null
           ports:
-            - containerPort: 8080
+            - name: http
+              containerPort: 8080
           livenessProbe:
             httpGet:
               path: /

--- a/config-root/namespaces/myapps/nodey554/nodey554-svc.yaml
+++ b/config-root/namespaces/myapps/nodey554/nodey554-svc.yaml
@@ -4,11 +4,8 @@ kind: Service
 metadata:
   name: nodey554
   labels:
-    chart: "nodey554-1.0.44"
+    chart: "nodey554-1.0.45"
     gitops.jenkins-x.io/pipeline: 'namespaces'
-  annotations:
-    fabric8.io/expose: "true"
-    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
   namespace: myapps
 spec:
   type: ClusterIP

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,7 +40,7 @@
 		    </tr>
 	    <tr>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> nodey554 </a></td>
-	      <td>1.0.44</td>
+	      <td>1.0.45</td>
 	      <td><a href='http://nodey554-myapps.34.118.108.125.nip.io'>view</a></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -90,7 +90,7 @@
     repositoryName: dev
     repositoryUrl: http://chartmuseum-jx.35.242.181.72.nip.io/
     resourcePath: config-root/namespaces/myapps/nodey554
-    version: 1.0.44
+    version: 1.0.45
   - apiVersion: v1
     applicationUrl: http://go-chaos-myapps.34.118.108.125.nip.io
     description: A Helm chart for Kubernetes

--- a/helmfiles/myapps/helmfile.yaml
+++ b/helmfiles/myapps/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://chartmuseum-jx.35.242.181.72.nip.io/
 releases:
 - chart: dev/nodey554
-  version: 1.0.44
+  version: 1.0.45
   name: nodey554
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote nodey554 to version 1.0.45

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
