### PR TITLE
chore: promote node-example to version 0.0.3

### DIFF
--- a/config-root/namespaces/myapps/node-example/node-example-ingress.yaml
+++ b/config-root/namespaces/myapps/node-example/node-example-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: node-example/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: node-example
+  namespace: myapps
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: node-example
+              servicePort: 80
+      host: node-example-myapps.34.118.108.125.nip.io

--- a/config-root/namespaces/myapps/node-example/node-example-node-example-deploy.yaml
+++ b/config-root/namespaces/myapps/node-example/node-example-node-example-deploy.yaml
@@ -1,0 +1,60 @@
+# Source: node-example/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: node-example-node-example
+  labels:
+    draft: draft-app
+    chart: "node-example-0.0.3"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: myapps
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: node-example-node-example
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: node-example-node-example
+    spec:
+      serviceAccountName: node-example-node-example
+      containers:
+        - name: node-example
+          image: "gcr.io/jenkins-x-labs-bdd1/node-example:0.0.3"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.3
+          envFrom: null
+          ports:
+            - name: http
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:
+        - name: "tekton-container-registry-auth"

--- a/config-root/namespaces/myapps/node-example/node-example-node-example-sa.yaml
+++ b/config-root/namespaces/myapps/node-example/node-example-node-example-sa.yaml
@@ -1,0 +1,8 @@
+# Source: node-example/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-example-node-example
+  namespace: myapps
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/myapps/node-example/node-example-svc.yaml
+++ b/config-root/namespaces/myapps/node-example/node-example-svc.yaml
@@ -1,0 +1,18 @@
+# Source: node-example/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: node-example
+  labels:
+    chart: "node-example-0.0.3"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: myapps
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: node-example-node-example

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,12 @@
 	      <td><a href='http://go-chaos-myapps.34.118.108.125.nip.io'>view</a></td>
 	      <td></td>
 	    </tr>
+    <tr>
+	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> node-example </a></td>
+	      <td>0.0.3</td>
+	      <td><a href='http://node-example-myapps.34.118.108.125.nip.io'>view</a></td>
+	      <td></td>
+	    </tr>
 
   </tbody>
 </table>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -4,6 +4,7 @@
   - apiVersion: v2
     appVersion: v2.4.0
     description: An operator for synthetic test and monitoring. Works great with Prometheus.
+    firstDeployed: "2021-04-28T06:49:49Z"
     home: https://comcast.github.io/kuberhealthy/
     icon: https://raw.githubusercontent.com/Comcast/kuberhealthy/master/images/logo-square.png
     keywords:
@@ -16,6 +17,7 @@
     - comcast
     - health
     - prometheus
+    lastDeployed: "2021-04-28T06:49:49Z"
     maintainers:
     - email: eric.greer@comcast.com
       name: integrii
@@ -39,8 +41,10 @@
   - apiVersion: v2
     appVersion: 3.0.0
     description: Jenkins X next gen cloud CI / CD platform for Kubernetes
+    firstDeployed: "2021-04-28T06:49:49Z"
     home: https://jenkins-x.io/
     icon: https://jenkins-x.github.io/jenkins-x-website/img/profile.png
+    lastDeployed: "2021-04-28T06:49:49Z"
     maintainers:
     - email: jenkins-x@googlegroups.com
       name: Jenkins X Team
@@ -60,12 +64,14 @@
     apiVersion: v2
     appVersion: 0.41.2
     description: Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer
+    firstDeployed: "2021-04-28T06:49:49Z"
     home: https://github.com/kubernetes/ingress-nginx
     icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png
     keywords:
     - ingress
     - nginx
     kubeVersion: '>=1.16.0-0'
+    lastDeployed: "2021-04-28T06:49:49Z"
     maintainers:
     - name: ChiefAlexander
     name: ingress-nginx
@@ -82,10 +88,12 @@
   - apiVersion: v1
     applicationUrl: http://nodey554-myapps.34.118.108.125.nip.io
     description: A Helm chart for Kubernetes
+    firstDeployed: "2021-04-28T06:49:52Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
     ingresses:
     - name: nodey554
       url: http://nodey554-myapps.34.118.108.125.nip.io
+    lastDeployed: "2021-04-28T06:49:52Z"
     name: nodey554
     repositoryName: dev
     repositoryUrl: http://chartmuseum-jx.35.242.181.72.nip.io/
@@ -94,12 +102,28 @@
   - apiVersion: v1
     applicationUrl: http://go-chaos-myapps.34.118.108.125.nip.io
     description: A Helm chart for Kubernetes
+    firstDeployed: "2021-04-28T06:49:52Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
     ingresses:
     - name: go-chaos
       url: http://go-chaos-myapps.34.118.108.125.nip.io
+    lastDeployed: "2021-04-28T06:49:52Z"
     name: go-chaos
     repositoryName: dev
     repositoryUrl: http://chartmuseum-jx.35.242.181.72.nip.io/
     resourcePath: config-root/namespaces/myapps/go-chaos
+    version: 0.0.3
+  - apiVersion: v1
+    applicationUrl: http://node-example-myapps.34.118.108.125.nip.io
+    description: A Helm chart for Kubernetes
+    firstDeployed: "2021-04-28T06:49:55Z"
+    icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
+    ingresses:
+    - name: node-example
+      url: http://node-example-myapps.34.118.108.125.nip.io
+    lastDeployed: "2021-04-28T06:49:55Z"
+    name: node-example
+    repositoryName: dev
+    repositoryUrl: http://chartmuseum-jx.35.242.181.72.nip.io/
+    resourcePath: config-root/namespaces/myapps/node-example
     version: 0.0.3

--- a/helmfiles/myapps/helmfile.yaml
+++ b/helmfiles/myapps/helmfile.yaml
@@ -18,5 +18,8 @@ releases:
   name: go-chaos
   values:
   - jx-values.yaml
+- chart: dev/node-example
+  version: 0.0.3
+  name: node-example
 templates: {}
 renderedvalues: {}

--- a/helmfiles/myapps/helmfile.yaml
+++ b/helmfiles/myapps/helmfile.yaml
@@ -21,5 +21,7 @@ releases:
 - chart: dev/node-example
   version: 0.0.3
   name: node-example
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote node-example to version 0.0.3

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
