### PR TITLE
chore: promote node-example to version 0.0.8

### DIFF
--- a/config-root/namespaces/myapps/node-example/node-example-node-example-deploy.yaml
+++ b/config-root/namespaces/myapps/node-example/node-example-node-example-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: node-example-node-example
   labels:
     draft: draft-app
-    chart: "node-example-0.0.7"
+    chart: "node-example-0.0.8"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'node-example'
@@ -25,11 +25,11 @@ spec:
       serviceAccountName: node-example-node-example
       containers:
         - name: node-example
-          image: "gcr.io/jenkins-x-labs-bdd1/node-example:0.0.7"
+          image: "gcr.io/jenkins-x-labs-bdd1/node-example:0.0.8"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.7
+              value: 0.0.8
           envFrom: null
           ports:
             - name: http

--- a/config-root/namespaces/myapps/node-example/node-example-svc.yaml
+++ b/config-root/namespaces/myapps/node-example/node-example-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: node-example
   labels:
-    chart: "node-example-0.0.7"
+    chart: "node-example-0.0.8"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'node-example'

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,7 +52,7 @@
 	    </tr>
     <tr>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> node-example </a></td>
-	      <td>0.0.7</td>
+	      <td>0.0.8</td>
 	      <td><a href='http://node-example-myapps.34.118.108.125.nip.io'>view</a></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -114,16 +114,17 @@
     resourcePath: config-root/namespaces/myapps/go-chaos
     version: 0.0.3
   - apiVersion: v1
+    appVersion: 0.0.8
     applicationUrl: http://node-example-myapps.34.118.108.125.nip.io
     description: A Helm chart for Kubernetes
-    firstDeployed: "2021-05-07T19:51:16Z"
+    firstDeployed: "2021-05-10T16:34:22Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
     ingresses:
     - name: node-example
       url: http://node-example-myapps.34.118.108.125.nip.io
-    lastDeployed: "2021-05-07T19:51:16Z"
+    lastDeployed: "2021-05-10T16:34:22Z"
     name: node-example
     repositoryName: dev
     repositoryUrl: http://chartmuseum-jx.35.242.181.72.nip.io/
     resourcePath: config-root/namespaces/myapps/node-example
-    version: 0.0.7
+    version: 0.0.8

--- a/helmfiles/myapps/helmfile.yaml
+++ b/helmfiles/myapps/helmfile.yaml
@@ -19,7 +19,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/node-example
-  version: 0.0.7
+  version: 0.0.8
   name: node-example
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote node-example to version 0.0.8

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
