### PR TITLE
chore: promote nodey554 to version 1.0.50

### DIFF
--- a/helmfiles/myapps/helmfile.yaml
+++ b/helmfiles/myapps/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://chartmuseum-jx.35.242.181.72.nip.io/
 releases:
 - chart: dev/nodey554
-  version: 1.0.45
+  version: 1.0.50
   name: nodey554
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote nodey554 to version 1.0.50

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
