### PR TITLE
chore: promote node-example to version 0.0.11

### DIFF
--- a/helmfiles/myapps/helmfile.yaml
+++ b/helmfiles/myapps/helmfile.yaml
@@ -19,7 +19,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/node-example
-  version: 0.0.7
+  version: 0.0.11
   name: node-example
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote node-example to version 0.0.11

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
